### PR TITLE
Use persistence-api alternative to hibernate-jpa-2.1-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile group: 'org.springframework.data', name: 'spring-data-commons', version: '1.12.6.RELEASE'
     compile group: 'org.springframework', name: 'spring-jdbc', version: springVersion
     compile group: 'org.springframework', name: 'spring-context', version: springVersion
-    compile group: 'org.hibernate.javax.persistence', name: 'hibernate-jpa-2.1-api', version: '1.0.0.Final'
+    compile group: 'javax.persistence', name: 'persistence-api', version: '1.0.2'
     compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
spring-data-jdbc-template uses javax.persistence api only.
It is not needed that spring-data-jdbc-template has a hibernate dependency.